### PR TITLE
Mods: display settings tabs from state

### DIFF
--- a/admin/qtx_admin_settings.php
+++ b/admin/qtx_admin_settings.php
@@ -244,33 +244,22 @@ class QTX_Admin_Settings {
     }
 
     private function add_sections( $nonce_action ) {
-        global $q_config;
-
         $admin_sections             = array();
         $admin_sections['general']  = __( 'General', 'qtranslate' );
         $admin_sections['advanced'] = __( 'Advanced', 'qtranslate' );
-
-        $custom_sections = apply_filters( 'qtranslate_admin_sections', array() );
+        $custom_sections            = apply_filters( 'qtranslate_admin_sections', array() );
         foreach ( $custom_sections as $key => $value ) {
             $admin_sections[ $key ] = $value;
         }
-
         $admin_sections['integration'] = __( 'Integration', 'qtranslate' );
-        $admin_sections['import']      = __( 'Import', 'qtranslate' ) . '/' . __( 'Export', 'qtranslate' );
-        $admin_sections['languages']   = __( 'Languages', 'qtranslate' );
-
-        //TODO: this actually assumes every manual activation module has settings, dedicated key to be added if that is not the case...
-        if ( isset( $q_config['ma_module_enabled'] ) ) {
-            foreach ( $q_config['ma_module_enabled'] as $module_id => $module_enabled ) {
-                if ( ! $module_enabled ) {
-                    continue;
-                }
-                $ma_module                    = QTX_Modules_Handler::get_module_def_by_id( $module_id );
-                $admin_sections[ $module_id ] = $ma_module['name'];
+        foreach ( QTX_Modules_Handler::get_active_modules() as $module ) {
+            if ( isset( $module ['has_settings'] ) && $module ['has_settings'] ) {
+                $admin_sections[ $module['id'] ] = $module['name'];
             }
         }
+        $admin_sections['import']          = __( 'Import', 'qtranslate' ) . '/' . __( 'Export', 'qtranslate' );
+        $admin_sections['languages']       = __( 'Languages', 'qtranslate' );
         $admin_sections['troubleshooting'] = __( 'Troubleshooting', 'qtranslate' );
-
         ?>
         <h2 class="nav-tab-wrapper">
             <?php foreach ( $admin_sections as $slug => $name ) : ?>

--- a/qtranslate_core.php
+++ b/qtranslate_core.php
@@ -124,7 +124,7 @@ function qtranxf_init_language() {
 
     qtranxf_load_option_qtrans_compatibility();
 
-    QTX_Modules_Handler::load_modules_enabled();
+    QTX_Modules_Handler::load_active_modules();
 
     /**
      * allow other plugins and modules to initialize whatever they need for language


### PR DESCRIPTION
The tab display is independent from its manual activation.
Any module could have extra settings (e.g. ACF).

Make the display dependent on the module state instead.
Add a new `has_settings` field in the module defintions.
Rename `load_modules_enabled` to `load_active_modules`.